### PR TITLE
Fix Tool-tip position in Firefox for pie charts

### DIFF
--- a/react-c3js.js
+++ b/react-c3js.js
@@ -52,7 +52,7 @@ var C3Chart = function (_React$Component) {
             mouse = d3.mouse(element);
         if (navigator.userAgent.indexOf("Firefox") != -1) {
           // this works in Firefox
-          mouse = [d3.event.offsetX - tWidth / 2 + 20, d3.event.offsetY - tHeight - 20];
+          mouse = [d3.event.offsetX - 80, d3.event.offsetY - 80];
         }
         // Determin tooltip position
         if (forArc) {
@@ -83,8 +83,10 @@ var C3Chart = function (_React$Component) {
         if (tooltipTop < 0) {
           tooltipTop = 0;
         }
+
         return { top: tooltipTop, left: tooltipLeft };
       };
+
       this.updateChart(this.props);
     }
   }, {

--- a/react-c3js.js
+++ b/react-c3js.js
@@ -41,6 +41,50 @@ var C3Chart = function (_React$Component) {
     key: 'componentDidMount',
     value: function componentDidMount() {
       c3 = require('c3');
+
+      // function override
+      c3.chart.internal.fn.tooltipPosition = function (dataToShow, tWidth, tHeight, element) {
+        var $$ = this,
+            config = $$.config,
+            d3 = $$.d3;
+        var svgLeft, tooltipLeft, tooltipRight, tooltipTop, chartRight;
+        var forArc = $$.hasArcType(),
+            mouse = d3.mouse(element);
+        if (navigator.userAgent.indexOf("Firefox") != -1) {
+          // this works in Firefox
+          mouse = [d3.event.offsetX - tWidth / 2 + 20, d3.event.offsetY - tHeight - 20];
+        }
+        // Determin tooltip position
+        if (forArc) {
+          tooltipLeft = ($$.width - ($$.isLegendRight ? $$.getLegendWidth() : 0)) / 2 + mouse[0];
+          tooltipTop = $$.height / 2 + mouse[1] + 20;
+        } else {
+          svgLeft = $$.getSvgLeft(true);
+          if (config.axis_rotated) {
+            tooltipLeft = svgLeft + mouse[0] + 100;
+            tooltipRight = tooltipLeft + tWidth;
+            chartRight = $$.currentWidth - $$.getCurrentPaddingRight();
+            tooltipTop = $$.x(dataToShow[0].x) + 20;
+          } else {
+            tooltipLeft = svgLeft + $$.getCurrentPaddingLeft(true) + $$.x(dataToShow[0].x) + 20;
+            tooltipRight = tooltipLeft + tWidth;
+            chartRight = svgLeft + $$.currentWidth - $$.getCurrentPaddingRight();
+            tooltipTop = mouse[1] + 15;
+          }
+
+          if (tooltipRight > chartRight) {
+            // 20 is needed for Firefox to keep tooltip width
+            tooltipLeft -= tooltipRight - chartRight + 20;
+          }
+          if (tooltipTop + tHeight > $$.currentHeight) {
+            tooltipTop -= tHeight + 30;
+          }
+        }
+        if (tooltipTop < 0) {
+          tooltipTop = 0;
+        }
+        return { top: tooltipTop, left: tooltipLeft };
+      };
       this.updateChart(this.props);
     }
   }, {

--- a/src/index.js
+++ b/src/index.js
@@ -46,6 +46,50 @@ class C3Chart extends React.Component {
 
   componentDidMount() {
     c3 = require('c3');
+
+    // function override
+    c3.chart.internal.fn.tooltipPosition = function (dataToShow, tWidth, tHeight, element) {
+      var $$ = this,
+          config = $$.config,
+          d3 = $$.d3;
+      var svgLeft, tooltipLeft, tooltipRight, tooltipTop, chartRight;
+      var forArc = $$.hasArcType(),
+          mouse = d3.mouse(element);
+      if (navigator.userAgent.indexOf("Firefox") != -1) {
+        // this works in Firefox
+        mouse = [d3.event.offsetX - tWidth / 2 + 20, d3.event.offsetY - tHeight - 20];
+      }
+      // Determin tooltip position
+      if (forArc) {
+        tooltipLeft = ($$.width - ($$.isLegendRight ? $$.getLegendWidth() : 0)) / 2 + mouse[0];
+        tooltipTop = $$.height / 2 + mouse[1] + 20;
+      } else {
+        svgLeft = $$.getSvgLeft(true);
+        if (config.axis_rotated) {
+          tooltipLeft = svgLeft + mouse[0] + 100;
+          tooltipRight = tooltipLeft + tWidth;
+          chartRight = $$.currentWidth - $$.getCurrentPaddingRight();
+          tooltipTop = $$.x(dataToShow[0].x) + 20;
+        } else {
+          tooltipLeft = svgLeft + $$.getCurrentPaddingLeft(true) + $$.x(dataToShow[0].x) + 20;
+          tooltipRight = tooltipLeft + tWidth;
+          chartRight = svgLeft + $$.currentWidth - $$.getCurrentPaddingRight();
+          tooltipTop = mouse[1] + 15;
+        }
+
+        if (tooltipRight > chartRight) {
+          // 20 is needed for Firefox to keep tooltip width
+          tooltipLeft -= tooltipRight - chartRight + 20;
+        }
+        if (tooltipTop + tHeight > $$.currentHeight) {
+          tooltipTop -= tHeight + 30;
+        }
+      }
+      if (tooltipTop < 0) {
+        tooltipTop = 0;
+      }
+      return { top: tooltipTop, left: tooltipLeft };
+    };
     this.updateChart(this.props);
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -57,7 +57,7 @@ class C3Chart extends React.Component {
           mouse = d3.mouse(element);
       if (navigator.userAgent.indexOf("Firefox") != -1) {
         // this works in Firefox
-        mouse = [d3.event.offsetX - tWidth / 2 + 20, d3.event.offsetY - tHeight - 20];
+        mouse = [d3.event.offsetX - 80, d3.event.offsetY - 80];
       }
       // Determin tooltip position
       if (forArc) {
@@ -88,8 +88,10 @@ class C3Chart extends React.Component {
       if (tooltipTop < 0) {
         tooltipTop = 0;
       }
+
       return { top: tooltipTop, left: tooltipLeft };
     };
+
     this.updateChart(this.props);
   }
 


### PR DESCRIPTION
This issue is due to a firefox/d3 bug.
When the transform is applied on the parent card, `d3.mouse` function doesn't return the correct value in firefox.

https://bugzilla.mozilla.org/show_bug.cgi?id=1610093

This solution has been based on some workaround suggested here.
https://github.com/d3/d3-selection/issues/81
and https://github.com/d3/d3-selection/issues/191

Basically, function `tooltipPosition` overridden by the copy of the same function with minor change for firefox useragent.
